### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,27 +1,27 @@
-﻿#######################################
+#######################################
 # Syntax Coloring Map For GFRTC
 #######################################
 
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-GFRTC				KEYWORD1
-RTC					KEYWORD1
+GFRTC	KEYWORD1
+RTC	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-get					KEYWORD2
-set					KEYWORD2
-read				KEYWORD2
-write				KEYWORD2
-writeNVRAM			KEYWORD2
-readNVRAM			KEYWORD2
-chipPresent			KEYWORD2
+get	KEYWORD2
+set	KEYWORD2
+read	KEYWORD2
+write	KEYWORD2
+writeNVRAM	KEYWORD2
+readNVRAM	KEYWORD2
+chipPresent	KEYWORD2
 #######################################
 # Instances (KEYWORD2)
 #######################################
-GFRTC				KEYWORD1
-RTC					KEYWORD2
+GFRTC	KEYWORD1
+RTC	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style highlighting  to be used (as with KEYWORD2, KEYWORD3). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special highlighting.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords